### PR TITLE
Use more conventional data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ in:
   schema:
     myid: primary_key
     name: string
-    score: integer
+    score: long
 ```
 
 - type: specify this plugin as `random`
@@ -45,7 +45,7 @@ in:
   schema:
     id: primary_key
     name: string
-    score: integer
+    score: long
 out:
   type: stdout
 ```
@@ -83,11 +83,11 @@ You can insert arbitrary storage via Embulk!
 ### Data Type
 
 Now supported types are belows
-- string: 32bytes of ascii code string
-- integer: random integer 0 to 10000
 - primary_key: increasing number for each rows
-- float: random floating point 0 to 10000
-- date: random date from 1970 to now
+- string: 32bytes of ascii code string
+- long, integer, int: random integer 0 to 10000
+- double, float: random floating point 0 to 10000
+- timestamp, date: random time from 1970 to now
 
 More and more types will be appended...
 

--- a/lib/embulk/input/random.rb
+++ b/lib/embulk/input/random.rb
@@ -24,7 +24,7 @@ module Embulk
           Column.new(index, attr, :long)
         when "double", "float"
           Column.new(index, attr, :double)
-        when "date"
+        when "date", "timestamp"
           Column.new(index, attr, :timestamp)
         end
       }
@@ -58,7 +58,7 @@ module Embulk
                               n
                             when 'float', 'double'
                               Random.rand * 10000
-                            when 'date'
+                            when 'date', "timestamp"
                               Time.at(rand * Time.now.to_f)
                             else
                               raise "unknown type: #{type}"


### PR DESCRIPTION
As *List of types* in http://www.embulk.org/docs/built-in.html#csv-parser-plugin shows, boolean, long, timestamp, double, string are more conventional keywords in the embulk world.

This PR adds `timestamp` data type in addition to `date`, and changes keywords used in the example on README.md.